### PR TITLE
Restore summary page

### DIFF
--- a/src/components/Summary.js
+++ b/src/components/Summary.js
@@ -251,7 +251,7 @@ class SummaryRow extends Component {
                 <div>{
                     this.makeLink(
                         repoFeature.repo,
-                        repoFeature.label,
+                        repoFeature.labels,
                         ['is:open'].concat(repoFeature.todo.others.concat(repoFeature.wip.others).map(issue => issue.number)),
                         repoFeature.todo.others.concat(repoFeature.wip.others)
                     )


### PR DESCRIPTION
The summary URLs were failing to load on the latest published version.